### PR TITLE
Use different DCO action implementation

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -10,12 +10,5 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Get PR Commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@v1.1.0
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
+        uses: tisonkun/actions-dco@v1.1


### PR DESCRIPTION
Switching from <https://github.com/tim-actions/dco> to <https://github.com/tisonkun/actions-dco>. While both implementations look very similar there are some differences:

- The later implementation does not require use of additional action to pull PR commits because it does not rely on `commits` being setup in `core` context.
- The later implementation is explicit about its LICENSE (AL2).

## Description

Describe your PR and add links to relevant issues.

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
