### PR TITLE
Add number shards by node

### DIFF
--- a/src/yamlRestTest/resources/rest-api-spec/test/70_10_nodes_shards_number.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/70_10_nodes_shards_number.yml
@@ -1,0 +1,31 @@
+"Cluster nodes shards (nodes_shards_number)":
+
+  # We expect no indices in the cluster 
+  - do:
+      indices.refresh: { allow_no_indices: true }
+
+  - do:
+      cluster.stats: {}
+
+  - match: { indices.count: 0 }
+
+  - do:
+      index:
+        index:  twitter
+        id:     1
+        body:   { foo: bar, settings: { number_of_shards: 5 } }
+  
+  - do:
+      indices.refresh: { allow_no_indices: true }
+
+  # Verify in Prometheus metrics that we get metrics only from a single node (the _local one):
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        opensearch_nodes_shards_number\{
+            cluster="yamlRestTest",node="[a-zA-Z0-9\-\.\_]+",nodeid="[a-zA-Z0-9\-\.\_]+"
+        \,} \s \d+\.\d+ (\n\#|![\n])
+        .*/


### PR DESCRIPTION
## Description

https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch/issues/189

Following the issue opened by arob1n, I made some modifications to the source code to add the metric that gives the number of shard per node. I've named the metric nodes_shards_number.

---

- [ ] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
