### PR TITLE
Update broken links to opensearch docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ prometheus.metric_name.prefix: "opensearch_"
 
 ### Dynamic settings
 
-Dynamic settings are configured in `config/opensearch.yml` but they can also be [updated](https://opensearch.org/docs/latest/opensearch/configuration/#update-cluster-settings-using-the-api) at any time via REST API.
+Dynamic settings are configured in `config/opensearch.yml` but they can also be [updated](https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index/#updating-cluster-settings-using-the-api) at any time via REST API.
 
 #### Index level metrics
 
@@ -155,7 +155,7 @@ Metrics include statistics about individual OpenSearch nodes.
 By default, only statistics from the node that received the request are included.
 
 Prometheus exporter can be configured to include statistics from other nodes as well.
-This filter is directly utilizing OpenSearch [Node filters](https://opensearch.org/docs/latest/opensearch/rest-api/nodes-apis/index/#node-filters) feature.
+This filter is directly utilizing OpenSearch [Node filters](https://opensearch.org/docs/latest/api-reference/nodes-apis/index/#node-filters) feature.
 Default value: `"_local"`.
 
 For example to get stats for all cluster nodes from any node use settings:


### PR DESCRIPTION
## Description

Updating some broken links to opensearch docs

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
