### PR TITLE
Upgrade exporter to be compatible with OpenSearch 2.18.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #group = org.opensearch.plugin.prometheus
 
-version = 2.17.1.0
+version = 2.18.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
## Description

Upgrades exporter to be compatible with [OpenSearch 2.18.0](https://github.com/opensearch-project/OpenSearch/releases/tag/2.18.0)

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
