### PR TITLE
Add default value for prometheus.cluster.settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ prometheus.indices: false
 
 #### Cluster settings
 
+Whether to export cluster settings metrics or not. Default value: `true`.
+
 To disable exporting cluster settings use:
 ```
 prometheus.cluster.settings: false


### PR DESCRIPTION
## Description

Add default value in documentation for `prometheus.cluster.settings`

Closes https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch/issues/297

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
