### PR TITLE
BWC testing: remove hardcoded OpenSearch version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,11 +174,15 @@ task copyZIPBundle {
     }
 }
 
+// A hack. For some reason we can not reference 'ext' variables from testClusters, hence we define actual opensearch
+// version the following way which seems to work fine for testClusters. See issue #324
+project.opensearch_version = ext.versions.opensearch
+
 // Clusters for BWC tests
 2.times { i ->
     testClusters {
         "${baseName}$i" {
-            versions = [project.BWCversion, "2.17.1"]
+            versions = [project.BWCversion, project.opensearch_version]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@
 # An actual version of plugin
 version = 2.17.1.0
 
+# Leave this property empty, it is assigned during the gradle build execution (yes, it is a hack! see issue #324)
+opensearch_version =
+
 # A version of OpenSearch cluster to run BWC tests against
 BWCversion = 2.17.0
 


### PR DESCRIPTION
## Description

In order to remove hardcoded version of actual OpenSearch from BWC versions array we need to introduce new 'empty' property and update it before testClusters are defined.

Closes: #324

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
