### PR TITLE
Add v2.18.0 on compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ NOTE: OpenSearch plugins much match _exactly_ in major.minor.path version to the
 
 | OpenSearch |      Plugin |  Release date |
 |-----------:|------------:|--------------:|
+|     2.18.0 |    2.18.0.0 |  Jan 22, 2025 |
 |     2.17.1 |    2.17.1.0 |  Oct 02, 2024 |
 |     2.17.0 |    2.17.0.0 |  Sep 26, 2024 |
 |     2.16.0 |    2.16.0.0 |  Aug 08, 2024 |


### PR DESCRIPTION
## Description

Adding the new 2.18.0 OpenSearch version on the compatibility table. 
This change is needed for closing https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch/issues/317
I put January 13 as a tentative date, since the tag is not yet created, I'm happy to adapt accordingly once the tag is available.

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
