### PR TITLE
correct the label from "unassigned" to "delayed_unassigned"

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -121,7 +121,7 @@ public class PrometheusMetricsCollector {
 
             catalog.setClusterGauge("cluster_shards_number", chr.getActiveShards(), "active");
             catalog.setClusterGauge("cluster_shards_number", chr.getActivePrimaryShards(), "active_primary");
-            catalog.setClusterGauge("cluster_shards_number", chr.getDelayedUnassignedShards(), "unassigned");
+            catalog.setClusterGauge("cluster_shards_number", chr.getDelayedUnassignedShards(), "delayed_unassigned");
             catalog.setClusterGauge("cluster_shards_number", chr.getInitializingShards(), "initializing");
             catalog.setClusterGauge("cluster_shards_number", chr.getRelocatingShards(), "relocating");
             catalog.setClusterGauge("cluster_shards_number", chr.getUnassignedShards(), "unassigned");


### PR DESCRIPTION
## Description

Describe your PR and add links to relevant issues.

This change provides separation between unassigned shards and delayed unassigned shards.

- [ ] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
